### PR TITLE
OCL Tree refresh changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,11 +79,21 @@
         "contents": "Load an OCL file to see the document outline, or:\n[Add new OCL file](command:oclOutline.addEntry)"
       }
     ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "oclOutline.refreshEntry",
+          "when": "view == oclOutline",
+          "group": "navigation"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "oclOutline.refreshEntry",
         "title": "Refresh",
-        "category": "Octopus"
+        "category": "Octopus",
+        "icon": "$(extensions-refresh)"
       }
     ]
   },


### PR DESCRIPTION
- Add icon for manual refresh in view
- Add auto tree refresh on a timeout following last doc change event
- Fixed new document button to create a new untitled file already with OCL set as lang