### PR TITLE
Welcome view improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "viewsWelcome": [
       {
         "view": "oclOutline",
-        "contents": "Load an OCL file to see the document outline, or:\n[Add new OCL file](command:oclOutline.addEntry)"
+        "contents": "Load an OCL file to see the document outline, or:\n[Add new OCL file](command:oclOutline.addEntry)",
+        "when": "!octopus.activeEditorIsOcl"
       }
     ],
     "menus": {
@@ -93,7 +94,8 @@
         "command": "oclOutline.refreshEntry",
         "title": "Refresh",
         "category": "Octopus",
-        "icon": "$(extensions-refresh)"
+        "icon": "$(extensions-refresh)",
+        "enablement": "octopus.activeEditorIsOcl"
       }
     ],
     "configuration": {

--- a/src/client/services/ocl-outline-provider.ts
+++ b/src/client/services/ocl-outline-provider.ts
@@ -132,12 +132,16 @@ export class OclOutline {
 	constructor() {
 		this.oclOutlineProvider = new OclOutlineProvider(vscode.workspace.rootPath);
 
+		this.setActiveEditorOclContext(vscode.window.activeTextEditor?.document.languageId === 'ocl');
+
 		vscode.window.registerTreeDataProvider(OCL_EXPLORER_ID, this.oclOutlineProvider);
 		vscode.window.onDidChangeActiveTextEditor(e => {
 			if (e?.document.languageId === OCL_LANGUAGE_ID) {
+				this.setActiveEditorOclContext(true);
 				this.oclOutlineProvider.refresh();
 			} else {
 				this.oclOutlineProvider.clear();
+				this.setActiveEditorOclContext(false);
 			}
 		});
 
@@ -147,6 +151,7 @@ export class OclOutline {
 				.then(_ => {
 					if (vscode.window.activeTextEditor) {
 						vscode.languages.setTextDocumentLanguage(vscode.window.activeTextEditor.document, OCL_LANGUAGE_ID);
+						this.setActiveEditorOclContext(true);
 					}
 				});
 		});
@@ -179,5 +184,9 @@ export class OclOutline {
 		if (this.userSettings.get('oclTreeRefreshType') === 'on save') {
 			this.onSaveDisposable = vscode.workspace.onDidSaveTextDocument(_ => this.oclOutlineProvider.refresh());
 		}
+	}
+
+	private setActiveEditorOclContext(isOcl: boolean) {
+		vscode.commands.executeCommand('setContext', 'octopus.activeEditorIsOcl', isOcl);
 	}
 }


### PR DESCRIPTION
- Only show welcome view when a non-ocl file is active in editor
- Disable welcome view on 'Add new OCL file' action
- Disable refresh button on OCL outline when a non-ocl file is active in editor